### PR TITLE
getLayout <<NaN>> fixed  and animationContainerStyles attribute #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ export default class App extends React.Component {
 | startUp | bool | true | If **true**, the drawer will start in up position. If **false**, it will start in down position. |
 | roundedEdges | bool | true | If **true**, the top of the drawer will have rounded edges. |
 | shadow | bool | true | if **true**, the top of the drawer will have a shadow. |
+| animationContainerStyles | Object | -- | Animated.View Styles|
 
 ### Questions?
 Feel free to contact me at [jackdillklein@gmail.com](mailto:jackdillklein@gmail.com) or [create an issue](https://github.com/jacklein/rn-bottom-drawer/issues/new)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-bottom-drawer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "a bottom drawer component for react native",
   "main": "index.js",
   "scripts": {

--- a/src/BottomDrawer.js
+++ b/src/BottomDrawer.js
@@ -4,7 +4,7 @@ import {
   View,
   PanResponder,
   Animated,
-  Dimensions,
+  Dimensions
 } from 'react-native';
 
 import styles from './styles';
@@ -50,6 +50,21 @@ export default class BottomDrawer extends Component{
      * Set to true to give the drawer a shadow.
      */
     shadow: PropTypes.bool,
+
+    /**
+     * Animated.View Styles
+     */
+    animationContainerStyles: PropTypes.object,
+
+    /*
+     * panResponder disabled then callback run responder func
+     */
+    panResponder: PropTypes.bool,
+
+    /*
+     * disabled panResponder then called.
+     */
+    responder: PropTypes.func
   }
 
   static defaultProps = {
@@ -58,6 +73,7 @@ export default class BottomDrawer extends Component{
     backgroundColor: '#ffffff',
     roundedEdges: true,
     shadow: true,
+    panResponder: true
   }
 
   constructor(props){
@@ -106,10 +122,9 @@ export default class BottomDrawer extends Component{
           { height: this.props.containerHeight + Math.sqrt(SCREEN_HEIGHT),
             backgroundColor: this.props.backgroundColor }
         ]}
-        {...this._panResponder.panHandlers}
+        {...(this.props.panResponder ? this._panResponder.panHandlers : {})}
       >
-        {this.props.children}
-
+        {this.props.panResponder ? this.props.children : this.props.responder(this._panResponder.panHandlers)}
         <View style={{height: Math.sqrt(SCREEN_HEIGHT), backgroundColor: this.props.backgroundColor}} />
       </Animated.View>
     )

--- a/src/BottomDrawer.js
+++ b/src/BottomDrawer.js
@@ -98,7 +98,7 @@ export default class BottomDrawer extends Component{
     return (
       <Animated.View 
         style={[
-          this.position.getLayout(),
+          {...this.position.getLayout(), left: 0 },
           styles.animationContainer,
           this.props.roundedEdges ? styles.roundedEdges : null,
           this.props.shadow ? styles.shadow : null,

--- a/src/BottomDrawer.js
+++ b/src/BottomDrawer.js
@@ -100,6 +100,7 @@ export default class BottomDrawer extends Component{
         style={[
           {...this.position.getLayout(), left: 0 },
           styles.animationContainer,
+          this.props.animationContainerStyles,
           this.props.roundedEdges ? styles.roundedEdges : null,
           this.props.shadow ? styles.shadow : null,
           { height: this.props.containerHeight + Math.sqrt(SCREEN_HEIGHT),


### PR DESCRIPTION
#8  The getLayout method returns an error when the left side returns NaN. This should be a default value.

And also do not need the left value.

Error:

Invariant Violation: Invariant Violation: [143,"RCTView",{"left":"<<NaN>>","top":563.4285714285714}] is not usable as a native method argument

and default **animationContainerStyles** attribute

Use:

  ```
    <BottomDrawer
        containerHeight={100}
        offset={TAB_BAR_HEIGHT}
        animationContainerStyles={{ zIndex: 10 }}
      >
        {this.renderContent()}
      </BottomDrawer>
```